### PR TITLE
Removed space in rules.responsive to prevent breaking in chrome(v47+)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ html {
 ###### What it outputs:
 ```css
 html {
-  font-size: calc(12px + 9 * ( (100vw - 420px) / 860));
+  font-size: calc(12px + 9 * ((100vw - 420px) / 860));
 }
 
 @media screen and (max-width: 420px) {

--- a/index.js
+++ b/index.js
@@ -120,7 +120,7 @@ module.exports = postcss.plugin('postcss-responsive-type', function () {
     // Build the responsive type decleration
     var sizeDiff = parseFloat(maxSize) - parseFloat(minSize),
         rangeDiff = parseFloat(maxWidth) - parseFloat(minWidth);
-    rules.responsive = 'calc(' + minSize + ' + ' + sizeDiff + ' * ( (100vw - ' + minWidth + ') / ' + rangeDiff + '))';
+    rules.responsive = 'calc(' + minSize + ' + ' + sizeDiff + ' * ((100vw - ' + minWidth + ') / ' + rangeDiff + '))';
 
     // Build the media queries
     rules.minMedia = postcss.atRule({

--- a/test/fixtures/custom.expected.css
+++ b/test/fixtures/custom.expected.css
@@ -1,5 +1,5 @@
 .foo {
-  font-size: calc(10px + 20 * ( (100vw - 300px) / 600));
+  font-size: calc(10px + 20 * ((100vw - 300px) / 600));
 }
 @media screen and (min-width: 900px) {
   .foo {

--- a/test/fixtures/default.expected.css
+++ b/test/fixtures/default.expected.css
@@ -1,5 +1,5 @@
 .foo {
-  font-size: calc(12px + 9 * ( (100vw - 420px) / 860));
+  font-size: calc(12px + 9 * ((100vw - 420px) / 860));
 }
 
 @media screen and (min-width: 1280px) {

--- a/test/fixtures/fallback.expected.css
+++ b/test/fixtures/fallback.expected.css
@@ -1,6 +1,6 @@
 .foo {
   font-size: 16px;
-  font-size: calc(12px + 9 * ( (100vw - 420px) / 860));
+  font-size: calc(12px + 9 * ((100vw - 420px) / 860));
 }
 @media screen and (min-width: 1280px) {
   .foo {

--- a/test/fixtures/formatting.expected.css
+++ b/test/fixtures/formatting.expected.css
@@ -1,5 +1,5 @@
 .foo {
-  font-size: calc(10px + 20 * ( (100vw - 300px) / 600));
+  font-size: calc(10px + 20 * ((100vw - 300px) / 600));
 }
 @media screen and (min-width: 900px) {
   .foo {

--- a/test/fixtures/mixed.expected.css
+++ b/test/fixtures/mixed.expected.css
@@ -1,5 +1,5 @@
 .foo {
-  font-size: calc(1rem + 2 * ( (100vw - 26.25rem) / 53.75));
+  font-size: calc(1rem + 2 * ((100vw - 26.25rem) / 53.75));
 }
 
 @media screen and (min-width: 1280px) {
@@ -17,7 +17,7 @@
 }
 
 .bar {
-  font-size: calc(1rem + 2 * ( (100vw - 20em) / 40));
+  font-size: calc(1rem + 2 * ((100vw - 20em) / 40));
 }
 
 @media screen and (min-width: 60em) {

--- a/test/fixtures/root.expected.css
+++ b/test/fixtures/root.expected.css
@@ -3,7 +3,7 @@ html {
 }
 
 .foo {
-  font-size: calc(1.6rem + 3.1999999999999997 * ( (100vw - 42rem) / 86));
+  font-size: calc(1.6rem + 3.1999999999999997 * ((100vw - 42rem) / 86));
 }
 
 @media screen and (min-width: 1280px) {

--- a/test/fixtures/shorthand.expected.css
+++ b/test/fixtures/shorthand.expected.css
@@ -1,5 +1,5 @@
 .foo {
-  font-size: calc(10px + 20 * ( (100vw - 300px) / 600));
+  font-size: calc(10px + 20 * ((100vw - 300px) / 600));
 }
 @media screen and (min-width: 900px) {
   .foo {


### PR DESCRIPTION
I had to remove a space here:   

```
rules.responsive = 'calc(' + minSize + ' + ' + sizeDiff + ' * ( (100vw - ' + minWidth + ') / ' + rangeDiff + '))';
```

This prevents the font-size calculation from breaking in Chrome(47+).
