### PR TITLE
Add em related tests and explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ html {
 ```
 
 ###### Specify parameters:
-Units can be in px, rem, or em.
+Units can be in px, rem, or em. When using em units, be sure that the `font-range` is specified in em as well.
 ```css
 html {
   font-size: responsive 12px 21px; /* min-size, max-size */

--- a/test/fixtures/em.css
+++ b/test/fixtures/em.css
@@ -1,0 +1,4 @@
+.foo {
+  font-size: responsive 1em 3em;
+  font-range: 20em 45em;
+}

--- a/test/fixtures/em.expected.css
+++ b/test/fixtures/em.expected.css
@@ -1,0 +1,13 @@
+.foo {
+  font-size: calc(1em + 2 * ((100vw - 20em) / 25));
+}
+@media screen and (min-width: 45em) {
+  .foo {
+    font-size: 3em;
+  }
+}
+@media screen and (max-width: 20em) {
+  .foo {
+    font-size: 1em;
+  }
+}

--- a/test/fixtures/mixed.css
+++ b/test/fixtures/mixed.css
@@ -7,3 +7,8 @@
   font-size: responsive 1rem 3rem;
   font-range: 20em 60em;
 }
+
+.baz {
+  font-size: responsive 1em 3em;
+  font-range: 420px 1280px;
+}

--- a/test/fixtures/mixed.expected.css
+++ b/test/fixtures/mixed.expected.css
@@ -33,3 +33,21 @@
     font-size: 1rem;
   }
 }
+
+.baz {
+  font-size: calc(1em + 2 * ((100vw - undefined) / NaN));
+}
+
+@media screen and (min-width: 1280px) {
+
+  .baz {
+    font-size: 3em;
+  }
+}
+
+@media screen and (max-width: 420px) {
+
+  .baz {
+    font-size: 1em;
+  }
+}

--- a/test/test.js
+++ b/test/test.js
@@ -44,6 +44,10 @@ describe('postcss-responsive-type', function() {
     test('mixed', {}, done);
   });
 
+  it('handles em units', function(done) {
+    test('em', {}, done);
+  });
+
   it('properly calculates rem from root font size', function(done) {
     test('root', {}, done);
   });

--- a/test/test.js
+++ b/test/test.js
@@ -7,7 +7,13 @@ var postcss = require('postcss'),
     path = require('path'),
     plugin = require('../');
 
-var test = function (fixture, opts, done) {
+var compareWarnings = function(warnings, expected) {
+  warnings.forEach(function (warning, i) {
+    expect(warning).to.contain(expected[i]);
+  });
+};
+
+var test = function (fixture, opts, warnings, done) {
   var input = fixture + '.css',
       expected = fixture + '.expected.css';
 
@@ -18,46 +24,57 @@ var test = function (fixture, opts, done) {
     .process(input)
     .then(function (result) {
       expect(result.css).to.eql(expected);
-      expect(result.warnings()).to.be.empty;
-    done();
-  }).catch(function (error) {
-    done(error);
-  });
+
+      if (warnings.length > 0) {
+        compareWarnings(result.warnings(), warnings);
+      } else {
+        expect(result.warnings()).to.be.empty;
+      }
+
+      done();
+    }).catch(function (error) {
+      done(error);
+    });
 
 };
 
 describe('postcss-responsive-type', function() {
 
   it('builds responsive type with defaults', function(done) {
-   test('default', {}, done);
+   test('default', {}, [], done);
   });
 
   it('applies custom parameters', function(done) {
-   test('custom', {}, done);
+   test('custom', {}, [], done);
   });
 
   it('works with shorthand properties', function(done) {
-   test('shorthand', {}, done);
+   test('shorthand', {}, [], done);
   });
 
   it('handles mixed units', function(done) {
-    test('mixed', {}, done);
+    test('mixed', {}, [{
+      type: 'warning',
+      text: 'this combination of units is not supported',
+      line: 11,
+      column: 1
+    }], done);
   });
 
   it('handles em units', function(done) {
-    test('em', {}, done);
+    test('em', {}, [], done);
   });
 
   it('properly calculates rem from root font size', function(done) {
-    test('root', {}, done);
+    test('root', {}, [], done);
   });
 
   it('doesn\'t kill fallbacks/duplicate properties', function(done) {
-   test('fallback', {}, done);
+   test('fallback', {}, [], done);
   });
 
   it('sanitizes inputs', function(done) {
-   test('formatting', {}, done);
+   test('formatting', {}, [], done);
   });
 
 });


### PR DESCRIPTION
Added tests to ensure correct behaviour in case `em` is used, also check that the correct warnings are output if the wrong units are mixed. Added small warning in readme for people using em units.
This should close https://github.com/seaneking/postcss-responsive-type/issues/17