### PR TITLE
Add infinite range option

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,36 @@ html {
 
 **Note:** Unitless line heights are not supported.
 
+##### Infinite ranges
+
+By adding the `infinite` option to any range property, the max width media query will be omitted and there will be no upper limit to your range. Sizes will continue scale beyond your upper range with the factor calculated by specified min/max values.
+
+```css
+html {
+  font-range: 420px 1280px infinite;
+
+  /* or extended syntax */
+  lower-font-range: 420px;
+  upper-font-range: 1280px infinite;
+}
+
+html {
+  line-height-range: 420px 1280px infinite;
+
+  /* or extended syntax */
+  lower-line-height-range: 420px;
+  upper-line-height-range: 1280px infinite;
+}
+
+html {
+  letter-spacing-range: 420px 1280px infinite;
+
+  /* or extended syntax */
+  lower-letter-spacing-range: 420px;
+  upper-letter-spacing-range: 1280px infinite;
+}
+```
+
 --
 
 ### Defaults

--- a/index.js
+++ b/index.js
@@ -97,7 +97,16 @@ module.exports = postcss.plugin('postcss-responsive-type', function () {
     rangeDecl = paramDecls[declName];
     Object.keys(rangeDecl).forEach(function(param){
       rule.walkDecls(rangeDecl[param], function(decl){
-        params[param] = decl.value.trim();
+
+        // Extract rangeOption from maxWith decl
+        if (param === 'maxWidth') {
+          var vals = decl.value.split(/\s+/);
+          params[param] = vals[0];
+          params['rangeOption'] = vals[1];
+        } else {
+          params[param] = decl.value.trim();
+        }
+
         decl.remove();
       });
     });

--- a/test/fixtures/infinite.css
+++ b/test/fixtures/infinite.css
@@ -1,0 +1,8 @@
+.foo {
+  font-size: responsive 10px 30px;
+  font-range: 300px 900px infinite;
+  letter-spacing: responsive 10px 30px;
+  letter-spacing-range: 300px 900px infinite;
+  line-height: responsive 10px 30px;
+  line-height-range: 300px 900px infinite;
+}

--- a/test/fixtures/infinite.expected.css
+++ b/test/fixtures/infinite.expected.css
@@ -1,0 +1,20 @@
+.foo {
+  font-size: calc(10px + 20 * ((100vw - 300px) / 600));
+  letter-spacing: calc(10px + 20 * ((100vw - 300px) / 600));
+  line-height: calc(10px + 20 * ((100vw - 300px) / 600));
+}
+@media screen and (max-width: 300px) {
+  .foo {
+    line-height: 10px;
+  }
+}
+@media screen and (max-width: 300px) {
+  .foo {
+    letter-spacing: 10px;
+  }
+}
+@media screen and (max-width: 300px) {
+  .foo {
+    font-size: 10px;
+  }
+}

--- a/test/fixtures/infinite_extended.css
+++ b/test/fixtures/infinite_extended.css
@@ -1,0 +1,11 @@
+.foo {
+  font-size: responsive 10px 30px;
+  lower-font-range: 300px;
+  upper-font-range: 900px infinite;
+  letter-spacing: responsive 10px 30px;
+  lower-letter-spacing-range: 300px;
+  upper-letter-spacing-range: 900px infinite;
+  line-height: responsive 10px 30px;
+  lower-line-height-range: 300px;
+  upper-line-height-range: 900px infinite;
+}

--- a/test/fixtures/infinite_extended.expected.css
+++ b/test/fixtures/infinite_extended.expected.css
@@ -1,0 +1,20 @@
+.foo {
+  font-size: calc(10px + 20 * ((100vw - 300px) / 600));
+  letter-spacing: calc(10px + 20 * ((100vw - 300px) / 600));
+  line-height: calc(10px + 20 * ((100vw - 300px) / 600));
+}
+@media screen and (max-width: 300px) {
+  .foo {
+    line-height: 10px;
+  }
+}
+@media screen and (max-width: 300px) {
+  .foo {
+    letter-spacing: 10px;
+  }
+}
+@media screen and (max-width: 300px) {
+  .foo {
+    font-size: 10px;
+  }
+}

--- a/test/test.js
+++ b/test/test.js
@@ -113,4 +113,8 @@ describe('postcss-responsive-type', function() {
    test('letterspacing_negative', {}, [], done);
   });
 
+  it('sets infinite range', function(done) {
+   test('infinite', {}, [], done);
+  });
+
 });

--- a/test/test.js
+++ b/test/test.js
@@ -117,4 +117,8 @@ describe('postcss-responsive-type', function() {
    test('infinite', {}, [], done);
   });
 
+  it('sets infinite range with extended syntax', function(done) {
+   test('infinite_extended', {}, [], done);
+  });
+
 });


### PR DESCRIPTION
By adding the `infinite` option to any range property, the max width media query will be omitted and there will be no upper limit to your range. Sizes will continue scale beyond your upper range with the factor calculated by the specified min/max values. This achieves infinite responsive type for any resolution.